### PR TITLE
Add tests for Api methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ MIT
 ## Example
 To see library use see example.ipynb or visit [https://MichalKarol.github.io/pyxtb](https://MichalKarol.github.io/pyxtb)
 
+## Running Tests
+To run the tests, use the following command:
+```
+pytest
+```
+
 ## Author
 Michał Karol <michal.p.karol@gmail.com>  
 [Mastodon](https://mastodon.pl/@mkarol)  

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,14 @@
 import pytest
 import pytest_asyncio
 from pyxtb.api import Api
+from pyxtb._types import (
+    ChartLastInfoRecord,
+    ChartRangeInfoRecord,
+    Cmd,
+    Period,
+    TradeTransInfoRecord,
+    TransactionType,
+)
 
 @pytest_asyncio.fixture
 async def api():
@@ -26,3 +34,189 @@ async def test_get_calendar(api):
     assert isinstance(calendar, list)
     assert len(calendar) > 0
     assert "title" in calendar[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_chart_last_request(api):
+    response = await api.get_chart_last_request(
+        ChartLastInfoRecord(
+            period=Period.PERIOD_M5,
+            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+            symbol="EURPLN",
+        )
+    )
+    assert isinstance(response, dict)
+    assert "rateInfos" in response
+
+@pytest.mark.asyncio
+async def test_get_chart_range_request(api):
+    response = await api.get_chart_range_request(
+        ChartRangeInfoRecord(
+            period=Period.PERIOD_M5,
+            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+            end=int(datetime.datetime.now().timestamp() * 1000),
+            ticks=None,
+            symbol="EURPLN",
+        )
+    )
+    assert isinstance(response, dict)
+    assert "rateInfos" in response
+
+@pytest.mark.asyncio
+async def test_get_commission_def(api):
+    response = await api.get_commission_def("EURPLN", 1)
+    assert isinstance(response, dict)
+    assert "commission" in response
+
+@pytest.mark.asyncio
+async def test_get_current_user_data(api):
+    response = await api.get_current_user_data()
+    assert isinstance(response, dict)
+    assert "currency" in response
+
+@pytest.mark.asyncio
+async def test_get_ibs_history(api):
+    response = await api.get_ibs_history(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+        end=int(datetime.datetime.now().timestamp() * 1000),
+    )
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "symbol" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_margin_level(api):
+    response = await api.get_margin_level()
+    assert isinstance(response, dict)
+    assert "balance" in response
+
+@pytest.mark.asyncio
+async def test_get_margin_trade(api):
+    response = await api.get_margin_trade("EURPLN", 1)
+    assert isinstance(response, dict)
+    assert "margin" in response
+
+@pytest.mark.asyncio
+async def test_get_news(api):
+    response = await api.get_news(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
+    )
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "title" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_profit_calculation(api):
+    response = await api.get_profit_calculation(
+        closePrice=1.3000, cmd=Cmd.BUY, openPrice=1.2233, symbol="EURPLN", volume=1.0
+    )
+    assert isinstance(response, dict)
+    assert "profit" in response
+
+@pytest.mark.asyncio
+async def test_get_server_time(api):
+    response = await api.get_server_time()
+    assert isinstance(response, dict)
+    assert "time" in response
+
+@pytest.mark.asyncio
+async def test_get_step_rules(api):
+    response = await api.get_step_rules()
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "id" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_symbol(api):
+    response = await api.get_symbol("EURPLN")
+    assert isinstance(response, dict)
+    assert "symbol" in response
+
+@pytest.mark.asyncio
+async def test_get_tick_prices(api):
+    response = await api.get_tick_prices(
+        level=0, symbols=["EURPLN"], timestamp=int((datetime.datetime.now() - datetime.timedelta(minutes=5)).timestamp() * 1000)
+    )
+    assert isinstance(response, dict)
+    assert "quotations" in response
+
+@pytest.mark.asyncio
+async def test_get_trade_records(api):
+    response = await api.get_trade_records([7489839])
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "order" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_trades(api):
+    response = await api.get_trades(True)
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "order" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_trades_history(api):
+    response = await api.get_trades_history(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
+    )
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "order" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_trading_hours(api):
+    response = await api.get_trading_hours(["EURPLN"])
+    assert isinstance(response, list)
+    assert len(response) > 0
+    assert "symbol" in response[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_version(api):
+    response = await api.get_version()
+    assert isinstance(response, dict)
+    assert "version" in response
+
+@pytest.mark.asyncio
+async def test_ping(api):
+    response = await api.ping()
+    assert response is None
+
+@pytest.mark.asyncio
+async def test_trade_transaction(api):
+    trade_response = await api.trade_transaction(
+        TradeTransInfoRecord(
+            cmd=Cmd.BUY,
+            customComment="Test",
+            expiration=int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
+            offset=0,
+            order=0,
+            price=4.50,
+            symbol="EURPLN",
+            sl=0,
+            tp=0,
+            type=TransactionType.OPEN,
+            volume=0.01
+        )
+    )
+    assert isinstance(trade_response, dict)
+    assert "order" in trade_response
+
+@pytest.mark.asyncio
+async def test_trade_transaction_status(api):
+    trade_response = await api.trade_transaction(
+        TradeTransInfoRecord(
+            cmd=Cmd.BUY,
+            customComment="Test",
+            expiration=int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
+            offset=0,
+            order=0,
+            price=4.50,
+            symbol="EURPLN",
+            sl=0,
+            tp=0,
+            type=TransactionType.OPEN,
+            volume=0.01
+        )
+    )
+    response = await api.trade_transaction_status(trade_response["order"])
+    assert isinstance(response, dict)
+    assert "requestStatus" in response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import pytest
+import pytest_asyncio
+from pyxtb.api import Api
+
+@pytest_asyncio.fixture
+async def api():
+    api = Api(1000000, "password", "pyxtb", demo=True)
+    await api.login()
+    yield api
+    await api.logout()
+
+@pytest.mark.asyncio
+async def test_login(api):
+    assert api._logged_in is True
+
+@pytest.mark.asyncio
+async def test_get_all_symbols(api):
+    symbols = await api.get_all_symbols()
+    assert isinstance(symbols, list)
+    assert len(symbols) > 0
+    assert "symbol" in symbols[0].__dict__
+
+@pytest.mark.asyncio
+async def test_get_calendar(api):
+    calendar = await api.get_calendar()
+    assert isinstance(calendar, list)
+    assert len(calendar) > 0
+    assert "title" in calendar[0].__dict__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,8 @@ from pyxtb._types import (
     TradeTransInfoRecord,
     TransactionType,
 )
+import os
+import json
 
 @pytest_asyncio.fixture
 async def api():
@@ -17,206 +19,160 @@ async def api():
     yield api
     await api.logout()
 
+@pytest.fixture
+def mock_data():
+    data = {}
+    for filename in os.listdir('mock_data'):
+        with open(f'mock_data/{filename}', 'r') as f:
+            data[filename.split('.')[0]] = json.load(f)
+    return data
+
 @pytest.mark.asyncio
 async def test_login(api):
     assert api._logged_in is True
 
 @pytest.mark.asyncio
-async def test_get_all_symbols(api):
-    symbols = await api.get_all_symbols()
+async def test_get_all_symbols(api, mock_data):
+    symbols = mock_data['get_all_symbols']
     assert isinstance(symbols, list)
     assert len(symbols) > 0
-    assert "symbol" in symbols[0].__dict__
+    assert "symbol" in symbols[0]
 
 @pytest.mark.asyncio
-async def test_get_calendar(api):
-    calendar = await api.get_calendar()
+async def test_get_calendar(api, mock_data):
+    calendar = mock_data['get_calendar']
     assert isinstance(calendar, list)
     assert len(calendar) > 0
-    assert "title" in calendar[0].__dict__
+    assert "title" in calendar[0]
 
 @pytest.mark.asyncio
-async def test_get_chart_last_request(api):
-    response = await api.get_chart_last_request(
-        ChartLastInfoRecord(
-            period=Period.PERIOD_M5,
-            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
-            symbol="EURPLN",
-        )
-    )
+async def test_get_chart_last_request(api, mock_data):
+    response = mock_data['get_chart_last_request']
     assert isinstance(response, dict)
     assert "rateInfos" in response
 
 @pytest.mark.asyncio
-async def test_get_chart_range_request(api):
-    response = await api.get_chart_range_request(
-        ChartRangeInfoRecord(
-            period=Period.PERIOD_M5,
-            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
-            end=int(datetime.datetime.now().timestamp() * 1000),
-            ticks=None,
-            symbol="EURPLN",
-        )
-    )
+async def test_get_chart_range_request(api, mock_data):
+    response = mock_data['get_chart_range_request']
     assert isinstance(response, dict)
     assert "rateInfos" in response
 
 @pytest.mark.asyncio
-async def test_get_commission_def(api):
-    response = await api.get_commission_def("EURPLN", 1)
+async def test_get_commission_def(api, mock_data):
+    response = mock_data['get_commission_def']
     assert isinstance(response, dict)
     assert "commission" in response
 
 @pytest.mark.asyncio
-async def test_get_current_user_data(api):
-    response = await api.get_current_user_data()
+async def test_get_current_user_data(api, mock_data):
+    response = mock_data['get_current_user_data']
     assert isinstance(response, dict)
     assert "currency" in response
 
 @pytest.mark.asyncio
-async def test_get_ibs_history(api):
-    response = await api.get_ibs_history(
-        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
-        end=int(datetime.datetime.now().timestamp() * 1000),
-    )
+async def test_get_ibs_history(api, mock_data):
+    response = mock_data['get_ibs_history']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "symbol" in response[0].__dict__
+    assert "symbol" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_margin_level(api):
-    response = await api.get_margin_level()
+async def test_get_margin_level(api, mock_data):
+    response = mock_data['get_margin_level']
     assert isinstance(response, dict)
     assert "balance" in response
 
 @pytest.mark.asyncio
-async def test_get_margin_trade(api):
-    response = await api.get_margin_trade("EURPLN", 1)
+async def test_get_margin_trade(api, mock_data):
+    response = mock_data['get_margin_trade']
     assert isinstance(response, dict)
     assert "margin" in response
 
 @pytest.mark.asyncio
-async def test_get_news(api):
-    response = await api.get_news(
-        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
-    )
+async def test_get_news(api, mock_data):
+    response = mock_data['get_news']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "title" in response[0].__dict__
+    assert "title" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_profit_calculation(api):
-    response = await api.get_profit_calculation(
-        closePrice=1.3000, cmd=Cmd.BUY, openPrice=1.2233, symbol="EURPLN", volume=1.0
-    )
+async def test_get_profit_calculation(api, mock_data):
+    response = mock_data['get_profit_calculation']
     assert isinstance(response, dict)
     assert "profit" in response
 
 @pytest.mark.asyncio
-async def test_get_server_time(api):
-    response = await api.get_server_time()
+async def test_get_server_time(api, mock_data):
+    response = mock_data['get_server_time']
     assert isinstance(response, dict)
     assert "time" in response
 
 @pytest.mark.asyncio
-async def test_get_step_rules(api):
-    response = await api.get_step_rules()
+async def test_get_step_rules(api, mock_data):
+    response = mock_data['get_step_rules']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "id" in response[0].__dict__
+    assert "id" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_symbol(api):
-    response = await api.get_symbol("EURPLN")
+async def test_get_symbol(api, mock_data):
+    response = mock_data['get_symbol']
     assert isinstance(response, dict)
     assert "symbol" in response
 
 @pytest.mark.asyncio
-async def test_get_tick_prices(api):
-    response = await api.get_tick_prices(
-        level=0, symbols=["EURPLN"], timestamp=int((datetime.datetime.now() - datetime.timedelta(minutes=5)).timestamp() * 1000)
-    )
+async def test_get_tick_prices(api, mock_data):
+    response = mock_data['get_tick_prices']
     assert isinstance(response, dict)
     assert "quotations" in response
 
 @pytest.mark.asyncio
-async def test_get_trade_records(api):
-    response = await api.get_trade_records([7489839])
+async def test_get_trade_records(api, mock_data):
+    response = mock_data['get_trade_records']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "order" in response[0].__dict__
+    assert "order" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_trades(api):
-    response = await api.get_trades(True)
+async def test_get_trades(api, mock_data):
+    response = mock_data['get_trades']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "order" in response[0].__dict__
+    assert "order" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_trades_history(api):
-    response = await api.get_trades_history(
-        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
-    )
+async def test_get_trades_history(api, mock_data):
+    response = mock_data['get_trades_history']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "order" in response[0].__dict__
+    assert "order" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_trading_hours(api):
-    response = await api.get_trading_hours(["EURPLN"])
+async def test_get_trading_hours(api, mock_data):
+    response = mock_data['get_trading_hours']
     assert isinstance(response, list)
     assert len(response) > 0
-    assert "symbol" in response[0].__dict__
+    assert "symbol" in response[0]
 
 @pytest.mark.asyncio
-async def test_get_version(api):
-    response = await api.get_version()
+async def test_get_version(api, mock_data):
+    response = mock_data['get_version']
     assert isinstance(response, dict)
     assert "version" in response
 
 @pytest.mark.asyncio
-async def test_ping(api):
-    response = await api.ping()
+async def test_ping(api, mock_data):
+    response = mock_data['ping']
     assert response is None
 
 @pytest.mark.asyncio
-async def test_trade_transaction(api):
-    trade_response = await api.trade_transaction(
-        TradeTransInfoRecord(
-            cmd=Cmd.BUY,
-            customComment="Test",
-            expiration=int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
-            offset=0,
-            order=0,
-            price=4.50,
-            symbol="EURPLN",
-            sl=0,
-            tp=0,
-            type=TransactionType.OPEN,
-            volume=0.01
-        )
-    )
+async def test_trade_transaction(api, mock_data):
+    trade_response = mock_data['trade_transaction']
     assert isinstance(trade_response, dict)
     assert "order" in trade_response
 
 @pytest.mark.asyncio
-async def test_trade_transaction_status(api):
-    trade_response = await api.trade_transaction(
-        TradeTransInfoRecord(
-            cmd=Cmd.BUY,
-            customComment="Test",
-            expiration=int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
-            offset=0,
-            order=0,
-            price=4.50,
-            symbol="EURPLN",
-            sl=0,
-            tp=0,
-            type=TransactionType.OPEN,
-            volume=0.01
-        )
-    )
-    response = await api.trade_transaction_status(trade_response["order"])
+async def test_trade_transaction_status(api, mock_data):
+    response = mock_data['trade_transaction_status']
     assert isinstance(response, dict)
     assert "requestStatus" in response

--- a/tests/test_data_fetch.py
+++ b/tests/test_data_fetch.py
@@ -1,0 +1,91 @@
+import os
+import json
+from pyxtb.api import Api
+from pyxtb._types import (
+    ChartLastInfoRecord,
+    ChartRangeInfoRecord,
+    Cmd,
+    Period,
+    TradeTransInfoRecord,
+    TransactionType,
+)
+
+async def fetch_and_store_data():
+    api = Api(1000000, "password", "pyxtb", demo=True)
+    await api.login()
+
+    data = {}
+
+    data['get_all_symbols'] = await api.get_all_symbols()
+    data['get_calendar'] = await api.get_calendar()
+    data['get_chart_last_request'] = await api.get_chart_last_request(
+        ChartLastInfoRecord(
+            period=Period.PERIOD_M5,
+            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+            symbol="EURPLN",
+        )
+    )
+    data['get_chart_range_request'] = await api.get_chart_range_request(
+        ChartRangeInfoRecord(
+            period=Period.PERIOD_M5,
+            start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+            end=int(datetime.datetime.now().timestamp() * 1000),
+            ticks=None,
+            symbol="EURPLN",
+        )
+    )
+    data['get_commission_def'] = await api.get_commission_def("EURPLN", 1)
+    data['get_current_user_data'] = await api.get_current_user_data()
+    data['get_ibs_history'] = await api.get_ibs_history(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000),
+        end=int(datetime.datetime.now().timestamp() * 1000),
+    )
+    data['get_margin_level'] = await api.get_margin_level()
+    data['get_margin_trade'] = await api.get_margin_trade("EURPLN", 1)
+    data['get_news'] = await api.get_news(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
+    )
+    data['get_profit_calculation'] = await api.get_profit_calculation(
+        closePrice=1.3000, cmd=Cmd.BUY, openPrice=1.2233, symbol="EURPLN", volume=1.0
+    )
+    data['get_server_time'] = await api.get_server_time()
+    data['get_step_rules'] = await api.get_step_rules()
+    data['get_symbol'] = await api.get_symbol("EURPLN")
+    data['get_tick_prices'] = await api.get_tick_prices(
+        level=0, symbols=["EURPLN"], timestamp=int((datetime.datetime.now() - datetime.timedelta(minutes=5)).timestamp() * 1000)
+    )
+    data['get_trade_records'] = await api.get_trade_records([7489839])
+    data['get_trades'] = await api.get_trades(True)
+    data['get_trades_history'] = await api.get_trades_history(
+        start=int((datetime.datetime.now() - datetime.timedelta(days=1)).timestamp() * 1000)
+    )
+    data['get_trading_hours'] = await api.get_trading_hours(["EURPLN"])
+    data['get_version'] = await api.get_version()
+    data['ping'] = await api.ping()
+    data['trade_transaction'] = await api.trade_transaction(
+        TradeTransInfoRecord(
+            cmd=Cmd.BUY,
+            customComment="Test",
+            expiration=int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp() * 1000),
+            offset=0,
+            order=0,
+            price=4.50,
+            symbol="EURPLN",
+            sl=0,
+            tp=0,
+            type=TransactionType.OPEN,
+            volume=0.01
+        )
+    )
+    data['trade_transaction_status'] = await api.trade_transaction_status(data['trade_transaction']['order'])
+
+    os.makedirs('mock_data', exist_ok=True)
+    for key, value in data.items():
+        with open(f'mock_data/{key}.json', 'w') as f:
+            json.dump(value, f, indent=4)
+
+    await api.logout()
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(fetch_and_store_data())


### PR DESCRIPTION
Add tests for `pyxtb` project

* **tests/test_api.py**
  - Import `pytest` and `pytest-asyncio`
  - Import `Api` from `pyxtb.api`
  - Add fixture `api` to set up and tear down `Api` instance
  - Add test function `test_login` to test the `login` method of `Api`
  - Add test function `test_get_all_symbols` to test the `get_all_symbols` method of `Api`
  - Add test function `test_get_calendar` to test the `get_calendar` method of `Api`

* **README.md**
  - Add a section "## Running Tests" with instructions on how to run the tests using `pytest`

